### PR TITLE
Fix UI state lock when initiating concurrent TLS scans

### DIFF
--- a/src/main/java/com/omnistrike/framework/tls/TlsAnalyzer.java
+++ b/src/main/java/com/omnistrike/framework/tls/TlsAnalyzer.java
@@ -204,6 +204,7 @@ public class TlsAnalyzer {
             if (existing == null) break;
             if (!existing.future.isDone()) {
                 log("Analysis already in progress for " + cacheKey);
+                if (onComplete != null) onComplete.accept(null);
                 return;
             }
             if (active.replace(cacheKey, existing, handle)) break;


### PR DESCRIPTION
Resolved an issue in `TlsAnalyzer.java` where initiating a scan for a target with an analysis already in progress returned early without executing the `onComplete` callback, leaving UI buttons and progress indicators in a permanently disabled state.